### PR TITLE
Fix tests and add graceful shutdown of the server nodes.

### DIFF
--- a/tts/integration_test/README.md
+++ b/tts/integration_test/README.md
@@ -1,0 +1,7 @@
+# tts_integration
+
+## Running instructions
+
+1. Make sure you have loaded valid AWS credentials with `polly:SynthesizeSpeech` service role access.
+2. `launch_test tts_integration.py`
+

--- a/tts/package.xml
+++ b/tts/package.xml
@@ -13,7 +13,7 @@
   <author email="ros-contributions@amazon.com">AWS RoboMaker</author>
 
   <exec_depend>tts_interfaces</exec_depend>
-  <exec_depend>python-boto3</exec_depend>
+  <exec_depend>python3-boto3</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 

--- a/tts/package.xml
+++ b/tts/package.xml
@@ -19,6 +19,8 @@
 
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_testing</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/tts/test/test_unit_polly.py
+++ b/tts/test/test_unit_polly.py
@@ -13,10 +13,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from __future__ import print_function
-
-
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import unittest
 
 

--- a/tts/test/test_unit_synthesizer.py
+++ b/tts/test/test_unit_synthesizer.py
@@ -13,9 +13,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from __future__ import print_function
-
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import unittest
 from pprint import pprint
 

--- a/tts/test/test_unit_synthesizer.py
+++ b/tts/test/test_unit_synthesizer.py
@@ -122,7 +122,7 @@ class TestSynthesizer(unittest.TestCase):
         source_file_dir = os.path.dirname(os.path.abspath(__file__))
         synthersizer_path = os.path.join(source_file_dir, '..', 'tts', 'services', 'synthesizer.py')
         import subprocess
-        o = subprocess.check_output(['python', synthersizer_path, '-h']).decode('utf-8')
+        o = subprocess.check_output(['python3', synthersizer_path, '-h']).decode('utf-8')
         self.assertTrue(str(o).startswith('Usage: '))
 
     @patch('tts.services.synthesizer.SynthesizerNode')

--- a/tts/tts/services/amazonpolly.py
+++ b/tts/tts/services/amazonpolly.py
@@ -383,10 +383,16 @@ def main():
 
     node = AmazonPollyNode(node_name, service_name)
 
-    rclpy.spin(node)
-
-    node.destroy_node()
-    rclpy.shutdown()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        print('Shutting down polly server')
+    except BaseException:
+        print('Exception in polly server:', file=sys.stderr)
+        raise
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
 
 
 if __name__ == '__main__':

--- a/tts/tts/services/synthesizer.py
+++ b/tts/tts/services/synthesizer.py
@@ -245,10 +245,16 @@ def main():
     else:
         node = SynthesizerNode(node_name=node_name, service_name=service_name, engine=engine)
 
-    rclpy.spin(node)
-
-    node.destroy_node()
-    rclpy.shutdown()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        print('Shutting down synthesizer server')
+    except BaseException:
+        print('Exception in synthesizer server:', file=sys.stderr)
+        raise
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Tested with:
1. `colcon build && colcon test && colcon test-result`
2. `launch_test tts/integration_test/tts_integration.py`

Note, this change will prevent the integration test from being run when `colcon test` is invoked; this is intentional as it requires AWS credentials, and is consistent with our ROS1 version (which uses rostest and doesn't run the integ tests, see https://travis-ci.org/aws-robotics/tts-ros1/jobs/578082718)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
