### PR TITLE
Fix voicer and bump version to 2.0.1

### DIFF
--- a/tts/package.xml
+++ b/tts/package.xml
@@ -1,13 +1,18 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>tts</name>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <description>Package enabling a robot to speak with a human voice by providing a Text-To-Speech ROS service</description>
   <maintainer email="ros-contributions@amazon.com">AWS RoboMaker</maintainer>
   <license>Apache License 2.0</license>
 
   <author>AWS RoboMaker</author>
   <author email="ros-contributions@amazon.com">AWS RoboMaker</author>
+
+  <exec_depend>python-gst-1.0</exec_depend>
+  <exec_depend>gstreamer1.0</exec_depend>
+  <exec_depend>gstreamer1.0-plugins-good</exec_depend>
+  <exec_depend>gstreamer1.0-alsa</exec_depend>
 
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>launch</exec_depend>

--- a/tts/setup.py
+++ b/tts/setup.py
@@ -5,7 +5,7 @@ package_name = 'tts'
 
 setup(
     name=package_name,
-    version='1.0.0',
+    version='2.0.1',
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/ament_index/resource_index/packages',

--- a/tts_interfaces/package.xml
+++ b/tts_interfaces/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>tts_interfaces</name>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <description>Contains message and service definitions used by tts.</description>
   <maintainer email="ros-contributions@amazon.com">AWS RoboMaker</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
* Add missing dependencies to package.xml
* Fix voicer to use async calls correctly instead of spinning itself forever
* Bump version to 2.0.1

Tested on RPi with a USB headset. First made sure I can play audio with alsa (`aplay`). For reference - to do that I took note of the card and device IDs returned from `aplay -l`, and created the file `~/.asoundrc` with:
```
pcm.!default {
  type plug
  slave {
    pcm "hw:<card-id>,<device-id>"
  }
}
```

Then running `ros2 run tts voicer 'Hello World'` with the changes here worked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
