### PR TITLE
Fix missed change to setup.py when voicer.py was moved

### DIFF
--- a/tts/setup.py
+++ b/tts/setup.py
@@ -38,7 +38,7 @@ setup(
         'console_scripts': [
             'polly_server = tts.services.amazonpolly:main',
             'synthesizer_server = tts.services.synthesizer:main',
-            'voicer = tts.voicer:main',
+            'voicer = tts.scripts.voicer:main',
         ],
     },
 )


### PR DESCRIPTION
*Description of changes:*

When moving `voicer.py` to the "scripts" directory in https://github.com/aws-robotics/tts-ros2/pull/13, a change was missed in `setup.py`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
